### PR TITLE
added ProgramDescriptionShort to Program schema

### DIFF
--- a/schemas/ppr_programs.json
+++ b/schemas/ppr_programs.json
@@ -14,6 +14,12 @@
       }
     },
     {
+      "name": "programdescriptionshort",
+      "knack_key": "field_371",
+      "knack_type": "paragraph_text",
+      "type": "string"
+    }, 
+    {
       "name": "facility",
       "knack_key": "field_47",
       "knack_type": "connection",


### PR DESCRIPTION
This new field is plain text, limited to 300 characters and should be used for program descriptions rendered in WP things to do / featured programs and the Finder's program details views.