### PR TITLE
added FaciltyIsPublished field

### DIFF
--- a/schemas/ppr_facilities.json
+++ b/schemas/ppr_facilities.json
@@ -20,6 +20,12 @@
       "type": "string"
     },
     {
+      "name": "facilityispublished",
+      "knack_key": "field_372",
+      "knack_type": "boolean",
+      "type": "boolean"
+    },
+    {
       "name": "location_contact_name",
       "knack_key": "field_370",
       "knack_type": "name",


### PR DESCRIPTION
This field will be used to manage what Facility table records show up in the Finder app regardless of their association with LocationType.